### PR TITLE
#14 - All specs video path

### DIFF
--- a/lib/VideoReporter.js
+++ b/lib/VideoReporter.js
@@ -26,6 +26,7 @@ function VideoReporter(options) {
     saveSuccessVideos: false,
     singleVideo: true,
     singleVideoPath: 'uuid',
+    allSpecsVideoName:'protractor-specs.mov',
     createSubtitles: true,
     ffmpegCmd: 'ffmpeg',
     ffmpegArgs: [
@@ -50,6 +51,10 @@ function VideoReporter(options) {
     singleVideoPath: Joi.alternatives().try(
         Joi.valid('uuid', 'fullName'),
         Joi.func()
+    ),
+    allSpecsVideoName:  Joi.alternatives().try(
+        Joi.func(),
+        Joi.string()
     ),
     createSubtitles: Joi.boolean()
         .description('If true and singleVideo is also true, will create a SRT subtitles file with the name details of the currently running spec.'),
@@ -139,6 +144,15 @@ VideoReporter.prototype._singleVideoPath = function(result) {
   }
 }
 
+VideoReporter.prototype._allSpecsVideoName = function(result) {
+    var self = this;
+
+    if ( typeof self.options.allSpecsVideoName === 'function') {
+        return self.options.allSpecsVideoName();
+    }
+
+    return self.options.allSpecsVideoName;
+}
 
 VideoReporter.prototype.specStarted = function(result) {
   var self = this;
@@ -198,7 +212,7 @@ VideoReporter.prototype.specDone = function(result) {
 VideoReporter.prototype.jasmineStarted = function() {
   var self = this;
   if (self.options.singleVideo) {
-    var videoPath = Path.join(self.options.baseDirectory, 'protractor-specs.mov');
+    var videoPath = Path.join(self.options.baseDirectory, self._allSpecsVideoName());
     self._startScreencast(videoPath);
 
     if (self.options.createSubtitles) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protractor-video-reporter",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "A jasmine2 reporter to capture a video screen cast of Protractor specs run with xvfb",
   "main": "index.js",
   "scripts": {

--- a/readme.md
+++ b/readme.md
@@ -56,6 +56,20 @@ For example, you can do:
         result.fullName + '.mov';
     }
 
+
+* `allSpecsVideoName`: (function):
+
+If you want to determine the full name of the single video file that will contain all specs, you can pass a string or function.
+You must also define `baseDirectory` path and set `singleVideo` as true to create a single video containing all specs.
+
+For example, you can do:
+
+    allSpecsVideoName: function (result) {
+        let timestamp = moment(new Date()).format('YYYYMMDD');
+        return 'protractor-specs_' + timestamp + '.avi';
+    },
+
+
 * `createSubtitles` (bool): If `true` and singleVideo is also true, will create a SRT subtitles file with the name details of the currently running spec. Defaults to `true`.
 The file will be saves to `baseDirectory/protractor-specs.srt`.
 


### PR DESCRIPTION
#14 - Allow specifying other name than protractor-specs.mov in case, when one video file is produced.

Added a new option called allSpecsVideoName which can be either a string or a function.   It is combined with the baseDirectory option to create a full path.